### PR TITLE
feat(ios): add AlarmKit alarms for early classes

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -5,10 +5,18 @@ import UIKit
 import UniformTypeIdentifiers
 import UserNotifications
 
+#if canImport(AlarmKit) && !targetEnvironment(macCatalyst)
+  import AlarmKit
+  import SwiftUI
+#endif
+
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   private var pendingImageSaveResult: FlutterResult?
   private var pendingImagePickerResult: FlutterResult?
+  private var earlyClassAlarmSyncTask: Task<Void, Never>?
+
+  private static let earlyClassAlarmIdsKey = "early_class_alarm_ids"
 
   override func application(
     _ application: UIApplication,
@@ -56,7 +64,178 @@ import UserNotifications
         result(FlutterMethodNotImplemented)
       }
     }
+    FlutterMethodChannel(
+      name: "work.shuyo.app/early_class_alarms",
+      binaryMessenger: engineBridge.applicationRegistrar.messenger()
+    ).setMethodCallHandler { [weak self] call, result in
+      self?.handleEarlyClassAlarm(call: call, result: result)
+    }
   }
+
+  private func handleEarlyClassAlarm(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    if call.method == "isAvailable" {
+      #if canImport(AlarmKit) && !targetEnvironment(macCatalyst)
+        if #available(iOS 26.0, *) {
+          result(true)
+        } else {
+          result(false)
+        }
+      #else
+        result(false)
+      #endif
+      return
+    }
+
+    #if canImport(AlarmKit) && !targetEnvironment(macCatalyst)
+      if #available(iOS 26.0, *) {
+        switch call.method {
+        case "requestAuthorization":
+          Task { @MainActor in
+            do {
+              let state = try await AlarmManager.shared.requestAuthorization()
+              result(state == .authorized)
+            } catch {
+              result(
+                FlutterError(
+                  code: "alarm_authorization_failed",
+                  message: error.localizedDescription,
+                  details: nil
+                )
+              )
+            }
+          }
+        case "sync":
+          guard
+            let arguments = call.arguments as? [String: Any],
+            let alarms = arguments["alarms"] as? [[String: Any]]
+          else {
+            result(
+              FlutterError(
+                code: "invalid_alarms",
+                message: "Expected an alarms list",
+                details: nil
+              )
+            )
+            return
+          }
+          let previousTask = earlyClassAlarmSyncTask
+          earlyClassAlarmSyncTask = Task { @MainActor [weak self] in
+            await previousTask?.value
+            await self?.syncEarlyClassAlarms(alarms, result: result)
+          }
+        default:
+          result(FlutterMethodNotImplemented)
+        }
+        return
+      }
+    #endif
+
+    result(
+      FlutterError(
+        code: "alarmkit_unavailable",
+        message: "AlarmKit requires iOS 26 or later",
+        details: nil
+      )
+    )
+  }
+
+  #if canImport(AlarmKit) && !targetEnvironment(macCatalyst)
+    @available(iOS 26.0, *)
+    @MainActor
+    private func syncEarlyClassAlarms(
+      _ rawAlarms: [[String: Any]],
+      result: @escaping FlutterResult
+    ) async {
+      let manager = AlarmManager.shared
+      let defaults = UserDefaults.standard
+      do {
+        let currentIDs = Set(try manager.alarms.map(\.id))
+        for rawID in defaults.stringArray(forKey: Self.earlyClassAlarmIdsKey) ?? [] {
+          guard
+            let id = UUID(uuidString: rawID),
+            currentIDs.contains(id)
+          else { continue }
+          try manager.cancel(id: id)
+        }
+      } catch {
+        result(
+          FlutterError(
+            code: "alarm_cancel_failed",
+            message: error.localizedDescription,
+            details: nil
+          )
+        )
+        return
+      }
+      defaults.removeObject(forKey: Self.earlyClassAlarmIdsKey)
+
+      guard manager.authorizationState == .authorized else {
+        result(-1)
+        return
+      }
+
+      let alarms = rawAlarms.compactMap { raw -> (Date, String)? in
+        guard
+          let milliseconds = raw["fireTime"] as? NSNumber,
+          let title = raw["title"] as? String
+        else {
+          return nil
+        }
+        let date = Date(timeIntervalSince1970: milliseconds.doubleValue / 1000)
+        return date > Date() ? (date, title) : nil
+      }
+      var scheduledIDs: [String] = []
+
+      for (date, title) in alarms {
+        let id = UUID()
+        let localizedTitle = LocalizedStringResource(stringLiteral: title)
+        let alert: AlarmPresentation.Alert
+        if #available(iOS 26.1, *) {
+          alert = AlarmPresentation.Alert(title: localizedTitle)
+        } else {
+          alert = AlarmPresentation.Alert(
+            title: localizedTitle,
+            stopButton: AlarmButton(
+              text: "停止",
+              textColor: .white,
+              systemImageName: "stop.circle.fill"
+            )
+          )
+        }
+        let attributes = AlarmAttributes<ShuYoAlarmMetadata>(
+          presentation: AlarmPresentation(alert: alert),
+          tintColor: .blue
+        )
+        let configuration = AlarmManager.AlarmConfiguration.alarm(
+          schedule: .fixed(date),
+          attributes: attributes
+        )
+
+        do {
+          try await manager.schedule(id: id, configuration: configuration)
+          scheduledIDs.append(id.uuidString)
+          defaults.set(scheduledIDs, forKey: Self.earlyClassAlarmIdsKey)
+        } catch AlarmManager.AlarmError.maximumLimitReached {
+          break
+        } catch {
+          defaults.set(scheduledIDs, forKey: Self.earlyClassAlarmIdsKey)
+          result(
+            FlutterError(
+              code: "alarm_sync_failed",
+              message: error.localizedDescription,
+              details: nil
+            )
+          )
+          return
+        }
+      }
+
+      defaults.set(scheduledIDs, forKey: Self.earlyClassAlarmIdsKey)
+      result(scheduledIDs.count)
+    }
+
+    private struct ShuYoAlarmMetadata: AlarmMetadata {}
+  #endif
 
   private func pickImage(result: @escaping FlutterResult) {
     guard pendingImagePickerResult == nil else {

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -28,6 +28,8 @@
 	<true/>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>将 ShuYo 中的图片保存到系统相册。</string>
+	<key>NSAlarmKitUsageDescription</key>
+	<string>用于为早课自动设置系统闹钟。</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/lib/data/services/academic_schedule_notification_service.dart
+++ b/lib/data/services/academic_schedule_notification_service.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:timezone/data/latest.dart' as timezone_data;
@@ -27,17 +29,42 @@ class AcademicScheduleNotificationSettings {
   }
 }
 
+class AcademicScheduleAlarmSettings {
+  const AcademicScheduleAlarmSettings({
+    required this.enabled,
+    required this.leadMinutes,
+  });
+
+  final bool enabled;
+  final int leadMinutes;
+
+  AcademicScheduleAlarmSettings copyWith({
+    bool? enabled,
+    int? leadMinutes,
+  }) {
+    return AcademicScheduleAlarmSettings(
+      enabled: enabled ?? this.enabled,
+      leadMinutes: leadMinutes ?? this.leadMinutes,
+    );
+  }
+}
+
 class AcademicScheduleNotificationService {
   AcademicScheduleNotificationService({
     required AcademicScheduleRepository repository,
     Future<SharedPreferences> Function()? preferencesLoader,
     FlutterLocalNotificationsPlugin? notifications,
+    MethodChannel? alarmChannel,
   })  : _repository = repository,
         _preferencesLoader = preferencesLoader ?? SharedPreferences.getInstance,
-        _notifications = notifications ?? FlutterLocalNotificationsPlugin();
+        _notifications = notifications ?? FlutterLocalNotificationsPlugin(),
+        _alarmChannel = alarmChannel ??
+            const MethodChannel('work.shuyo.app/early_class_alarms');
 
   static const _enabledKey = 'academic.schedule.notifications.enabled';
   static const _leadMinutesKey = 'academic.schedule.notifications.leadMinutes';
+  static const _alarmEnabledKey = 'academic.schedule.alarms.enabled';
+  static const _alarmLeadMinutesKey = 'academic.schedule.alarms.leadMinutes';
   static const _channelId = 'course_reminders';
   static const _baseNotificationId = 420000;
   static const _maxPendingReminders = 64;
@@ -45,6 +72,7 @@ class AcademicScheduleNotificationService {
   final AcademicScheduleRepository _repository;
   final Future<SharedPreferences> Function() _preferencesLoader;
   final FlutterLocalNotificationsPlugin _notifications;
+  final MethodChannel _alarmChannel;
   bool _initialized = false;
 
   Future<AcademicScheduleNotificationSettings> loadSettings() async {
@@ -88,7 +116,96 @@ class AcademicScheduleNotificationService {
     return saved;
   }
 
+  Future<bool> supportsEarlyClassAlarms() async {
+    if (kIsWeb || defaultTargetPlatform != TargetPlatform.iOS) {
+      return false;
+    }
+    try {
+      return await _alarmChannel.invokeMethod<bool>('isAvailable') ?? false;
+    } on MissingPluginException {
+      return false;
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  Future<AcademicScheduleAlarmSettings> loadAlarmSettings() async {
+    final prefs = await _preferencesLoader();
+    return AcademicScheduleAlarmSettings(
+      enabled: prefs.getBool(_alarmEnabledKey) ?? false,
+      leadMinutes: prefs.getInt(_alarmLeadMinutesKey) ?? 20,
+    );
+  }
+
+  Future<AcademicScheduleAlarmSettings> saveAlarmSettings(
+    AcademicScheduleAlarmSettings settings,
+  ) async {
+    final prefs = await _preferencesLoader();
+    final normalized = settings.copyWith(
+      leadMinutes: settings.leadMinutes.clamp(1, 120),
+    );
+    await prefs.setBool(_alarmEnabledKey, normalized.enabled);
+    await prefs.setInt(_alarmLeadMinutesKey, normalized.leadMinutes);
+    return normalized;
+  }
+
+  Future<AcademicScheduleAlarmSettings> saveAlarmSettingsAndSync(
+    AcademicScheduleAlarmSettings settings, {
+    bool requestPermission = false,
+  }) async {
+    var next = settings;
+    if (next.enabled && requestPermission) {
+      final allowed =
+          await _alarmChannel.invokeMethod<bool>('requestAuthorization') ??
+              false;
+      if (!allowed) {
+        next = next.copyWith(enabled: false);
+      }
+    }
+    await saveAlarmSettings(next);
+    await syncEarlyClassAlarms();
+    return loadAlarmSettings();
+  }
+
+  Future<int> syncEarlyClassAlarms({DateTime? now}) async {
+    if (!await supportsEarlyClassAlarms()) {
+      return 0;
+    }
+    await _ensureInitialized();
+    final settings = await loadAlarmSettings();
+    final schedule =
+        settings.enabled ? await _repository.loadCachedSchedule() : null;
+    final alarms = <_EarlyClassAlarm>[];
+    if (schedule != null) {
+      final weekState = await _repository.loadWeekState();
+      alarms.addAll(
+        _upcomingEarlyClassAlarms(
+          schedule: schedule,
+          weekState: weekState,
+          leadMinutes: settings.leadMinutes,
+          now: now ?? DateTime.now(),
+        ),
+      );
+    }
+    final count = await _alarmChannel.invokeMethod<int>('sync', {
+          'alarms': alarms.map((alarm) => alarm.toMap()).toList(),
+        }) ??
+        0;
+    if (count < 0) {
+      if (settings.enabled) {
+        await saveAlarmSettings(settings.copyWith(enabled: false));
+      }
+      return 0;
+    }
+    return count;
+  }
+
   Future<int> syncScheduleReminders({bool requestPermission = false}) async {
+    try {
+      await syncEarlyClassAlarms();
+    } on PlatformException {
+      // Local notification syncing remains independent of AlarmKit.
+    }
     await _ensureInitialized();
     await _cancelCourseReminders();
 
@@ -245,6 +362,69 @@ class AcademicScheduleNotificationService {
     }
   }
 
+  Iterable<_EarlyClassAlarm> _upcomingEarlyClassAlarms({
+    required AcademicSchedule schedule,
+    required ScheduleWeekState weekState,
+    required int leadMinutes,
+    required DateTime now,
+  }) sync* {
+    final shanghaiNow = timezone.TZDateTime.from(now, timezone.local);
+    final today =
+        DateTime(shanghaiNow.year, shanghaiNow.month, shanghaiNow.day);
+    final alarms = <_EarlyClassAlarm>[];
+    final maxDays = schedule.maxWeek * 7 + 7;
+
+    for (var dayOffset = 0; dayOffset < maxDays; dayOffset++) {
+      final day = today.add(Duration(days: dayOffset));
+      final week = _rawWeekForDate(weekState, day);
+      if (week < 1) {
+        continue;
+      }
+      if (schedule.isVacationWeek(week)) {
+        break;
+      }
+
+      CourseSession? earliest;
+      for (final session in schedule.sessions) {
+        final range =
+            AcademicScheduleRepository.sectionTimes[session.startSection];
+        final isMorning = range != null && range.$1 < 12;
+        if (session.weekday == day.weekday &&
+            session.occursInWeek(week) &&
+            isMorning &&
+            (earliest == null ||
+                session.startSection < earliest.startSection)) {
+          earliest = session;
+        }
+      }
+      if (earliest == null) {
+        continue;
+      }
+
+      final range =
+          AcademicScheduleRepository.sectionTimes[earliest.startSection]!;
+      final start = timezone.TZDateTime(
+        timezone.local,
+        day.year,
+        day.month,
+        day.day,
+        range.$1,
+        range.$2,
+      );
+      final fireTime = start.subtract(Duration(minutes: leadMinutes));
+      if (fireTime.isAfter(shanghaiNow.add(const Duration(seconds: 30)))) {
+        alarms.add(
+          _EarlyClassAlarm(
+            title: earliest.courseName.isEmpty ? '早课' : earliest.courseName,
+            fireTime: fireTime,
+          ),
+        );
+      }
+    }
+
+    yield* alarms;
+  }
+
   Iterable<_CourseReminder> _upcomingReminders({
     required AcademicSchedule schedule,
     required ScheduleWeekState weekState,
@@ -317,4 +497,16 @@ class _CourseReminder {
     final location = session.location.isEmpty ? '' : ' · ${session.location}';
     return '$leadMinutes 分钟后开始$location';
   }
+}
+
+class _EarlyClassAlarm {
+  const _EarlyClassAlarm({required this.title, required this.fireTime});
+
+  final String title;
+  final DateTime fireTime;
+
+  Map<String, Object> toMap() => {
+        'title': title,
+        'fireTime': fireTime.millisecondsSinceEpoch,
+      };
 }

--- a/lib/features/settings/client_settings_page.dart
+++ b/lib/features/settings/client_settings_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/client_app_info.dart';
@@ -728,10 +729,15 @@ class _NotificationSettingsPageState extends State<_NotificationSettingsPage> {
   ClientNotificationSettings? _settings;
   bool _saving = false;
 
+  bool _alarmsSupported = false;
+  AcademicScheduleAlarmSettings? _alarmSettings;
+  bool _savingAlarm = false;
+
   @override
   void initState() {
     super.initState();
     _future = _loadSettings();
+    _loadAlarmState();
   }
 
   @override
@@ -762,6 +768,7 @@ class _NotificationSettingsPageState extends State<_NotificationSettingsPage> {
             );
           }
           final settings = _settings ?? snapshot.data!;
+          final alarmSettings = _alarmSettings;
           return ListView(
             children: [
               _SettingsSwitchRow(
@@ -772,6 +779,27 @@ class _NotificationSettingsPageState extends State<_NotificationSettingsPage> {
                   settings.copyWith(scheduleEnabled: value),
                 ),
               ),
+              if (_alarmsSupported && alarmSettings != null) ...[
+                _SettingsSwitchRow(
+                  title: '早课闹钟',
+                  subtitle: '每天仅为上午最早的一节课设置闹钟',
+                  value: alarmSettings.enabled,
+                  enabled: !_savingAlarm,
+                  onChanged: (value) => _saveAlarm(
+                    alarmSettings.copyWith(enabled: value),
+                    requestPermission: value,
+                  ),
+                ),
+                if (alarmSettings.enabled)
+                  ListTile(
+                    title: const Text('闹钟提前时间'),
+                    trailing: Text('${alarmSettings.leadMinutes} 分钟'),
+                    enabled: !_savingAlarm,
+                    onTap: _savingAlarm
+                        ? null
+                        : () => _editAlarmLeadMinutes(alarmSettings),
+                  ),
+              ],
             ],
           );
         },
@@ -783,6 +811,22 @@ class _NotificationSettingsPageState extends State<_NotificationSettingsPage> {
     final settings = await widget.settingsService.loadNotificationSettings();
     _settings = settings;
     return settings;
+  }
+
+  Future<void> _loadAlarmState() async {
+    final supported =
+        await widget.scheduleNotificationService.supportsEarlyClassAlarms();
+    final settings = supported
+        ? await widget.scheduleNotificationService.loadAlarmSettings()
+        : const AcademicScheduleAlarmSettings(
+            enabled: false,
+            leadMinutes: 20,
+          );
+    if (!mounted) return;
+    setState(() {
+      _alarmsSupported = supported;
+      _alarmSettings = settings;
+    });
   }
 
   Future<void> _save(ClientNotificationSettings settings) async {
@@ -816,6 +860,96 @@ class _NotificationSettingsPageState extends State<_NotificationSettingsPage> {
       }
     }
   }
+
+  Future<void> _saveAlarm(
+    AcademicScheduleAlarmSettings settings, {
+    bool requestPermission = false,
+  }) async {
+    if (_savingAlarm) {
+      return;
+    }
+    setState(() {
+      _savingAlarm = true;
+      _alarmSettings = settings;
+    });
+    try {
+      final saved =
+          await widget.scheduleNotificationService.saveAlarmSettingsAndSync(
+        settings,
+        requestPermission: requestPermission,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() => _alarmSettings = saved);
+      if (settings.enabled && !saved.enabled) {
+        _showSnack(context, '未获得闹钟权限，请在系统设置中允许 ShuYo 使用闹钟');
+      }
+    } on Object catch (error) {
+      if (mounted) {
+        _showSnack(context, '闹钟设置保存失败：$error');
+        _loadAlarmState();
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _savingAlarm = false);
+      }
+    }
+  }
+
+  Future<void> _editAlarmLeadMinutes(
+    AcademicScheduleAlarmSettings settings,
+  ) async {
+    final formKey = GlobalKey<FormState>();
+    final controller = TextEditingController(
+      text: settings.leadMinutes.toString(),
+    );
+    final value = await showDialog<int>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('设置闹钟提前时间'),
+        content: Form(
+          key: formKey,
+          child: TextFormField(
+            controller: controller,
+            autofocus: true,
+            keyboardType: TextInputType.number,
+            textInputAction: TextInputAction.done,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            decoration: const InputDecoration(
+              labelText: '提前分钟数',
+              helperText: '可设置 1–120 分钟',
+            ),
+            validator: (text) {
+              final minutes = int.tryParse(text ?? '');
+              if (minutes == null || minutes < 1 || minutes > 120) {
+                return '请输入 1–120 之间的整数';
+              }
+              return null;
+            },
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('取消'),
+          ),
+          FilledButton(
+            onPressed: () {
+              if (formKey.currentState?.validate() ?? false) {
+                Navigator.of(dialogContext).pop(int.parse(controller.text));
+              }
+            },
+            child: const Text('保存'),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (value != null && mounted) {
+      await _saveAlarm(settings.copyWith(leadMinutes: value));
+    }
+  }
 }
 
 class _SettingsRow extends StatelessWidget {
@@ -843,12 +977,15 @@ class _SettingsSwitchRow extends StatelessWidget {
     required this.value,
     required this.enabled,
     required this.onChanged,
+    this.subtitle,
   });
 
   final String title;
   final bool value;
   final bool enabled;
   final ValueChanged<bool> onChanged;
+  final String? subtitle;
+
 
   @override
   Widget build(BuildContext context) {
@@ -860,6 +997,12 @@ class _SettingsSwitchRow extends StatelessWidget {
           color: enabled ? colors.textPrimary : colors.textMuted,
         ),
       ),
+      subtitle: subtitle == null
+          ? null
+          : Text(
+              subtitle!,
+              style: TextStyle(color: colors.textMuted),
+            ),
       value: value,
       onChanged: enabled ? onChanged : null,
     );

--- a/lib/features/settings/client_settings_page.dart
+++ b/lib/features/settings/client_settings_page.dart
@@ -793,7 +793,10 @@ class _NotificationSettingsPageState extends State<_NotificationSettingsPage> {
                 if (alarmSettings.enabled)
                   ListTile(
                     title: const Text('闹钟提前时间'),
-                    trailing: Text('${alarmSettings.leadMinutes} 分钟'),
+                    trailing: Padding(
+                      padding: const EdgeInsets.only(right: 7),
+                      child: Text('${alarmSettings.leadMinutes} 分钟'),
+                    ),
                     enabled: !_savingAlarm,
                     onTap: _savingAlarm
                         ? null

--- a/lib/features/settings/client_settings_page.dart
+++ b/lib/features/settings/client_settings_page.dart
@@ -901,9 +901,7 @@ class _NotificationSettingsPageState extends State<_NotificationSettingsPage> {
     AcademicScheduleAlarmSettings settings,
   ) async {
     final formKey = GlobalKey<FormState>();
-    final controller = TextEditingController(
-      text: settings.leadMinutes.toString(),
-    );
+    var input = settings.leadMinutes.toString();
     final value = await showDialog<int>(
       context: context,
       builder: (dialogContext) => AlertDialog(
@@ -911,7 +909,8 @@ class _NotificationSettingsPageState extends State<_NotificationSettingsPage> {
         content: Form(
           key: formKey,
           child: TextFormField(
-            controller: controller,
+            initialValue: input,
+            onChanged: (value) => input = value,
             autofocus: true,
             keyboardType: TextInputType.number,
             textInputAction: TextInputAction.done,
@@ -937,7 +936,7 @@ class _NotificationSettingsPageState extends State<_NotificationSettingsPage> {
           FilledButton(
             onPressed: () {
               if (formKey.currentState?.validate() ?? false) {
-                Navigator.of(dialogContext).pop(int.parse(controller.text));
+                Navigator.of(dialogContext).pop(int.parse(input));
               }
             },
             child: const Text('保存'),
@@ -945,7 +944,6 @@ class _NotificationSettingsPageState extends State<_NotificationSettingsPage> {
         ],
       ),
     );
-    controller.dispose();
     if (value != null && mounted) {
       await _saveAlarm(settings.copyWith(leadMinutes: value));
     }

--- a/test/academic_schedule_alarm_test.dart
+++ b/test/academic_schedule_alarm_test.dart
@@ -149,6 +149,20 @@ void main() {
       expect(methodCalls, contains('requestAuthorization'));
       expect(find.text('闹钟提前时间'), findsOneWidget);
       expect(find.text('20 分钟'), findsOneWidget);
+
+      await tester.tap(find.text('闹钟提前时间'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('取消'));
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+
+      await tester.tap(find.text('闹钟提前时间'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextFormField), '30');
+      await tester.tap(find.text('保存'));
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+      expect(find.text('30 分钟'), findsOneWidget);
     } finally {
       debugDefaultTargetPlatformOverride = null;
     }

--- a/test/academic_schedule_alarm_test.dart
+++ b/test/academic_schedule_alarm_test.dart
@@ -1,0 +1,231 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shuyo/data/models/academic_schedule.dart';
+import 'package:shuyo/data/repositories/academic_schedule_repository.dart';
+import 'package:shuyo/data/repositories/client_backend_repository.dart';
+import 'package:shuyo/data/services/academic_auth_service.dart';
+import 'package:shuyo/data/services/academic_schedule_api_client.dart';
+import 'package:shuyo/data/services/academic_schedule_notification_service.dart';
+import 'package:shuyo/data/services/client_settings_service.dart';
+import 'package:shuyo/features/settings/client_settings_page.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('test.shuyo/early_class_alarms');
+
+  late List<Map<Object?, Object?>> syncedAlarms;
+  late List<String> methodCalls;
+  late bool alarmAuthorized;
+
+  setUp(() {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    FlutterLocalNotificationsPlatform.instance =
+        _StubNotificationsPlatform();
+    SharedPreferences.setMockInitialValues({});
+    syncedAlarms = [];
+    methodCalls = [];
+    alarmAuthorized = true;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+      methodCalls.add(call.method);
+      switch (call.method) {
+        case 'isAvailable':
+          return true;
+        case 'requestAuthorization':
+          return alarmAuthorized;
+        case 'sync':
+          final arguments = call.arguments as Map<Object?, Object?>;
+          syncedAlarms = (arguments['alarms'] as List<Object?>)
+              .cast<Map<Object?, Object?>>();
+          return alarmAuthorized ? syncedAlarms.length : -1;
+      }
+      return null;
+    });
+  });
+
+  tearDown(() {
+    debugDefaultTargetPlatformOverride = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('AlarmKit sync schedules only each morning earliest class', () async {
+    final repository = AcademicScheduleRepository(
+      apiClient: _UnusedAcademicScheduleApiClient(),
+    );
+    await repository.saveCachedSchedule(_schedule);
+    await repository.setCurrentWeek(1, now: DateTime(2026, 8, 31));
+    final service = AcademicScheduleNotificationService(
+      repository: repository,
+      alarmChannel: channel,
+    );
+
+    expect(
+      await service.loadAlarmSettings(),
+      isA<AcademicScheduleAlarmSettings>()
+          .having((settings) => settings.enabled, 'enabled', isFalse)
+          .having((settings) => settings.leadMinutes, 'leadMinutes', 20),
+    );
+
+    await service.saveAlarmSettings(
+      const AcademicScheduleAlarmSettings(enabled: true, leadMinutes: 20),
+    );
+    final count = await service.syncEarlyClassAlarms(
+      now: DateTime.utc(2026, 8, 30, 21),
+    );
+
+    expect(count, 2);
+    expect(syncedAlarms.map((alarm) => alarm['title']), ['高等数学', '大学英语']);
+    expect(
+      syncedAlarms.map(
+        (alarm) => DateTime.fromMillisecondsSinceEpoch(
+          alarm['fireTime']! as int,
+          isUtc: true,
+        ),
+      ),
+      [DateTime.utc(2026, 8, 30, 23, 40), DateTime.utc(2026, 9, 1, 1, 40)],
+    );
+  });
+
+  test('AlarmKit sync disables stale setting when permission is revoked',
+      () async {
+    final service = AcademicScheduleNotificationService(
+      repository: AcademicScheduleRepository(
+        apiClient: _UnusedAcademicScheduleApiClient(),
+      ),
+      alarmChannel: channel,
+    );
+    await service.saveAlarmSettings(
+      const AcademicScheduleAlarmSettings(enabled: true, leadMinutes: 20),
+    );
+    alarmAuthorized = false;
+
+    final saved = await service.saveAlarmSettingsAndSync(
+      const AcademicScheduleAlarmSettings(enabled: true, leadMinutes: 30),
+    );
+
+    expect(saved.enabled, isFalse);
+    expect(saved.leadMinutes, 30);
+  });
+
+  testWidgets('iOS 26 settings request AlarmKit permission when enabled',
+      (tester) async {
+    try {
+      final repository = AcademicScheduleRepository(
+        apiClient: _UnusedAcademicScheduleApiClient(),
+      );
+      final alarmService = AcademicScheduleNotificationService(
+        repository: repository,
+        alarmChannel: channel,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ClientSettingsPage(
+            settingsService: ClientSettingsService(),
+            scheduleNotificationService: alarmService,
+            backendRepository: ClientBackendRepository(),
+            selectedThemeId: 'default',
+            followSystemTheme: false,
+            onThemeChanged: (_) async {},
+            onFollowSystemThemeChanged: (_) async {},
+          ),
+        ),
+      );
+      await tester.tap(find.text('通知设置'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('早课闹钟'), findsOneWidget);
+      expect(find.text('闹钟提前时间'), findsNothing);
+
+      await tester.tap(find.text('早课闹钟'));
+      await tester.pumpAndSettle();
+
+      expect(methodCalls, contains('requestAuthorization'));
+      expect(find.text('闹钟提前时间'), findsOneWidget);
+      expect(find.text('20 分钟'), findsOneWidget);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+}
+
+class _UnusedAcademicScheduleApiClient extends AcademicScheduleApiClient {
+  _UnusedAcademicScheduleApiClient()
+      : super(authService: _FakeAcademicAuthService());
+}
+
+class _FakeAcademicAuthService implements AcademicAuthService {
+  @override
+  Future<Set<String>> clearCookies() async => {};
+
+  @override
+  Future<void> markLoggedIn() async {}
+
+  @override
+  Future<String?> cookieHeader({Uri? targetUri}) async => null;
+
+  @override
+  Future<bool> hasWebVpnSession() async => false;
+
+  @override
+  Future<bool> hasAcademicSession() async => false;
+
+  @override
+  Future<WebVpnSessionStatus> validateDirectAcademicSession() async =>
+      WebVpnSessionStatus.loginRequired;
+
+  @override
+  Future<WebVpnSessionStatus> validateWebVpnSession() async =>
+      WebVpnSessionStatus.loginRequired;
+}
+
+CourseSession _session({
+  required String name,
+  required int weekday,
+  required int startSection,
+}) {
+  return CourseSession(
+    id: '$name-$weekday-$startSection',
+    courseName: name,
+    courseCode: '',
+    teacherName: '',
+    campus: '',
+    location: '',
+    weekday: weekday,
+    startSection: startSection,
+    endSection: startSection,
+    sections: [startSection],
+    weeks: const [1],
+    weekText: '1周',
+    credit: '',
+    note: '',
+  );
+}
+
+final _schedule = AcademicSchedule(
+  term: const AcademicTerm(
+    yearCode: '2026',
+    termCode: '3',
+    academicYearName: '2026-2027',
+    termName: '秋',
+    studentName: '',
+    studentId: '',
+    className: '',
+  ),
+  sessions: [
+    _session(name: '高等数学', weekday: DateTime.monday, startSection: 1),
+    _session(name: '线性代数', weekday: DateTime.monday, startSection: 3),
+    _session(name: '大学英语', weekday: DateTime.tuesday, startSection: 3),
+    _session(name: '体育', weekday: DateTime.wednesday, startSection: 5),
+  ],
+  untimedCourses: const [],
+  fetchedAt: DateTime(2026, 8, 31),
+);
+
+class _StubNotificationsPlatform extends FlutterLocalNotificationsPlatform {}


### PR DESCRIPTION
Refs #2 

## Summary

Add AlarmKit support on iOS 26+ to create an alarm for the earliest morning class each day, with a configurable lead time of 1–120 minutes.

## Compatibility

- iOS 26+: AlarmKit setting is available
- other: setting is hidden

## Verification

- [x] `flutter test`
- [x] `flutter analyze`
- [x] Tested on iOS 27 Beta 7