### PR TITLE
fix: 修复从 Widget 进入课表后缺少返回动画

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,10 @@
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
+            <!-- home_widget handles Widget launch URIs; avoid a second route push. -->
+            <meta-data
+                android:name="flutter_deeplinking_enabled"
+                android:value="false" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/lib/app/app_shell.dart
+++ b/lib/app/app_shell.dart
@@ -499,7 +499,7 @@ class _AppShellState extends State<AppShell> with WidgetsBindingObserver {
     _openingScheduleFromWidget = true;
     try {
       final navigation = _openAcademicSystem(
-        animated: false,
+        animatePush: false,
         initialState: initialLaunch ? widget.initialScheduleState : null,
         initialDisplayState:
             initialLaunch ? widget.initialScheduleDisplayState : null,
@@ -2301,13 +2301,13 @@ class _AppShellState extends State<AppShell> with WidgetsBindingObserver {
   }
 
   Future<void> _openAcademicSystem({
-    bool animated = true,
+    bool animatePush = true,
     AcademicScheduleCacheState? initialState,
     AcademicScheduleDisplayState? initialDisplayState,
     String? initialLoadError,
   }) async {
     final route = shuyoRoute<void>(
-      animated: animated,
+      animatePush: animatePush,
       builder: (context) => AcademicSchedulePage(
         repository: _scheduleRepository,
         notificationService: _scheduleNotificationService,

--- a/lib/shared/navigation/shuyo_route.dart
+++ b/lib/shared/navigation/shuyo_route.dart
@@ -7,6 +7,8 @@ Route<T> shuyoRoute<T>({
   RouteSettings? settings,
   bool fullscreenDialog = false,
   bool animated = true,
+  // Deep links can appear immediately while keeping the normal back transition.
+  bool animatePush = true,
 }) {
   if (!animated) {
     return PageRouteBuilder<T>(
@@ -21,7 +23,8 @@ Route<T> shuyoRoute<T>({
     );
   }
   if (defaultTargetPlatform == TargetPlatform.iOS) {
-    return CupertinoPageRoute<T>(
+    return _ShuYoCupertinoRoute<T>(
+      animatePush: animatePush,
       settings: settings,
       fullscreenDialog: fullscreenDialog,
       builder: (context) => _ShuYoRouteSurface(child: builder(context)),
@@ -31,7 +34,8 @@ Route<T> shuyoRoute<T>({
     settings: settings,
     fullscreenDialog: fullscreenDialog,
     opaque: true,
-    transitionDuration: const Duration(milliseconds: 240),
+    transitionDuration:
+        animatePush ? const Duration(milliseconds: 240) : Duration.zero,
     reverseTransitionDuration: const Duration(milliseconds: 210),
     pageBuilder: (context, animation, secondaryAnimation) {
       return _ShuYoRouteSurface(child: builder(context));
@@ -46,6 +50,26 @@ Route<T> shuyoRoute<T>({
       return SlideTransition(position: position, child: child);
     },
   );
+}
+
+// Keep the native back transition and interactive gesture handling even when
+// a Widget deep link skips the push animation.
+class _ShuYoCupertinoRoute<T> extends CupertinoPageRoute<T> {
+  _ShuYoCupertinoRoute({
+    required super.builder,
+    required this.animatePush,
+    super.settings,
+    super.fullscreenDialog,
+  });
+
+  final bool animatePush;
+
+  @override
+  Duration get transitionDuration =>
+      animatePush ? super.transitionDuration : Duration.zero;
+
+  @override
+  Duration get reverseTransitionDuration => super.transitionDuration;
 }
 
 class _ShuYoRouteSurface extends StatelessWidget {


### PR DESCRIPTION
## 改动摘要
修复 iOS 从 Widget 打开课表后，点击返回直接跳到首页、缺少过渡动画的问题。

实现：
增加 `animatePush` 参数，将进入动画和退出动画分开控制。使从 Widget 进入时可直接跳转并保留退出的过渡动画。

iOS 使用 `CupertinoPageRoute` 子类分别控制进入和返回时长，保留原生返回动画与侧滑手势；Android 在现有 `PageRouteBuilder` 中仅将进入时长设为零，保留原有返回时长。

由于 iOS 的 `CupertinoPageRoute` 没有提供独立设置进入/返回时长的参数，因此需要通过创建子类并通过覆盖属性调整。

## 关联 Issue
无

## 平台影响

- [x] iOS
- [x] Android 
- [ ] 不涉及平台代码

## 测试情况

- [x] 已运行 `flutter analyze`
- [x] 已运行 `flutter test`
- [x] 已进行真机或模拟器验证